### PR TITLE
パスワードのバリデーション変更

### DIFF
--- a/__tests__/lib/validation.js
+++ b/__tests__/lib/validation.js
@@ -35,12 +35,22 @@ describe('lib/validation', () => {
     test('パスワードが8文字以下', () => {
       const password = '1234ab'
       const ret = checkPassword(password)
-      expect(ret).toBe('英字/数字/記号の8文字以上100文字以内でお願いします')
+      expect(ret).toBe('英字/数字を含む8文字以上でお願いします')
     })
     test('パスワードで使用できない文字を使っている', () => {
       const password = 'あいうえおかきくけこさしすせそ'
       const ret = checkPassword(password)
-      expect(ret).toBe('英字/数字/記号の8文字以上100文字以内でお願いします')
+      expect(ret).toBe('英字/数字を含む8文字以上でお願いします')
+    })
+    test('数字だけのパスワード', () => {
+      const password = '12345678'
+      const ret = checkPassword(password)
+      expect(ret).toBe('英字/数字を含む8文字以上でお願いします')
+    })
+    test('英字だけのパスワード', () => {
+      const password = 'abcdefgh'
+      const ret = checkPassword(password)
+      expect(ret).toBe('英字/数字を含む8文字以上でお願いします')
     })
     test('正しいパスワード', () => {
       const password = '0)!($UTA$$$$$**FJEROIJF*RG})'

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -23,10 +23,10 @@ export function checkPassword(password) {
   }
 
   const regex = new RegExp(
-    /^([a-z\d\.\*\+\^\|\[\]\(\)\?\$\{\}\-\"\'\`_<>~!=#@$%&]){8,100}$/i
+    /^(?=.*?[a-z])(?=.*?\d)([a-z\d\.\*\+\^\|\[\]\(\)\?\$\{\}\-\"\'\`_<>~!=#@$%&]){8,100}$/i
   )
   if (!regex.exec(password)) {
-    return '英字/数字/記号の8文字以上100文字以内でお願いします'
+    return '英字/数字を含む8文字以上でお願いします'
   }
 
   return true


### PR DESCRIPTION
* パスワードのバリデーションを変更
  * 変更前：英字/数字/記号の8文字以上(数字だけの8文字や英字だけの8文字でもOK)
  * 変更後：英字/数字を含む8文字以上(記号は含まれていても含まれていなくてもOK)
* 参考
パスワード向け正規表現 /^(?=.*?[a-z])(?=.*?\d)[a-z\d]{8,100}$/i を解読する - Qiita
https://qiita.com/momotaro98/items/460c6cac14473765ec14