### PR TITLE
マイページ修正

### DIFF
--- a/components/pages/common/customer/Mail.vue
+++ b/components/pages/common/customer/Mail.vue
@@ -1,7 +1,12 @@
 <template>
   <div class="userinfo">
-
-    <v-layout row>
+    <v-layout v-if="isLabel" row>
+      <v-flex xs3>メールアドレス</v-flex>
+      <v-flex>
+        {{ mail }}
+      </v-flex>
+    </v-layout>
+    <v-layout v-else row>
       <v-flex xs3>メールアドレス<span class="must">(必須)</span></v-flex>
       <v-layout column>
         <v-flex>
@@ -45,6 +50,10 @@ import { checkMail, checkSame } from '~/lib/validation'
 
 export default {
   props: {
+    isLabel: {
+      type: Boolean,
+      default: false
+    },
     isConfirm: {
       type: Boolean,
       default: false

--- a/components/pages/common/customer/Mail.vue
+++ b/components/pages/common/customer/Mail.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="userinfo">
-    <v-layout v-if="isLabel" row>
+    <v-layout v-if="readOnly" row>
       <v-flex xs3>メールアドレス</v-flex>
       <v-flex>
         {{ mail }}
@@ -50,7 +50,7 @@ import { checkMail, checkSame } from '~/lib/validation'
 
 export default {
   props: {
-    isLabel: {
+    readOnly: {
       type: Boolean,
       default: false
     },

--- a/components/pages/complete/NextBtn.vue
+++ b/components/pages/complete/NextBtn.vue
@@ -2,7 +2,7 @@
   <div>
     <v-layout column>
       <v-flex xs6>
-        <v-btn color="warning" href="https://olivebodycare.jp/">店舗ホームページへ</v-btn>
+        <v-btn color="warning" href="https://olivebodycare.healthcare/">店舗ホームページへ</v-btn>
       </v-flex>
       <v-flex xs6>
         <v-btn color="warning" @click="goReserve">続けて予約する方へ</v-btn>

--- a/components/pages/mypage/Header.vue
+++ b/components/pages/mypage/Header.vue
@@ -15,7 +15,7 @@
     <v-btn dark class="mybtn bg_gray">
       横浜青葉台店<br>予約
     </v-btn>
-    <v-btn dark class="mybtn" href="https://olivebodycare.jp/">
+    <v-btn dark class="mybtn" href="https://olivebodycare.healthcare/">
       オリーブボディケア<br>店舗情報
     </v-btn>
     <v-btn dark class="mybtn" @click="profile">

--- a/components/pages/mypage/reservations/ReserveData.vue
+++ b/components/pages/mypage/reservations/ReserveData.vue
@@ -9,7 +9,7 @@
           <div class="text-value shop">{{ data.store.name }}</div>
         </v-flex>
         <v-flex v-if="isShownCancelButton" xs6 >
-          <v-btn class="cancel-btn" color="warning" @click="cancelConfrim(data.id)">キャンセル</v-btn>
+          <v-btn class="cancel-btn" color="warning" @click="cancelConfrim(data.id)">キャンセルする</v-btn>
         </v-flex>
       </v-layout>
       <v-layout row wrap>
@@ -126,5 +126,8 @@ export default {
 <style scoped>
 .cancel button .v-btn__content {
   font-size: 1em;
+}
+.cancel-btn {
+  width: 150px;
 }
 </style>

--- a/components/pages/mypage/reservations/ReserveHistory.vue
+++ b/components/pages/mypage/reservations/ReserveHistory.vue
@@ -1,7 +1,7 @@
 <template>
   <v-layout justify-center column>
     <template v-for="data in reserveData">
-      <v-flex 
+      <v-flex
         :key="data.id"
         d-flex
         xs12
@@ -72,8 +72,5 @@ export default {
 .card-main {
   margin-top: 12px;
   margin-bottom: 12px;
-}
-.cancel-btn {
-  width: 10px;
 }
 </style>

--- a/pages/create/confirm.vue
+++ b/pages/create/confirm.vue
@@ -12,7 +12,6 @@
           <customer-name :is-confirm="true"/>
           <customer-mail :is-confirm="true"/>
           <customer-phone-number :is-confirm="true"/>
-          <customer-adress :is-confirm="true"/>
           <customer-message :is-confirm="true"/>
           <customer-password :is-confirm="true"/>
           <fixed-btn />

--- a/pages/create/confirm.vue
+++ b/pages/create/confirm.vue
@@ -12,6 +12,7 @@
           <customer-name :is-confirm="true"/>
           <customer-mail :is-confirm="true"/>
           <customer-phone-number :is-confirm="true"/>
+          <customer-adress v-if="false" :is-confirm="true"/>
           <customer-message :is-confirm="true"/>
           <customer-password :is-confirm="true"/>
           <fixed-btn />

--- a/pages/mypage/profile/confirm.vue
+++ b/pages/mypage/profile/confirm.vue
@@ -12,6 +12,7 @@
       <customer-mail :is-label="true"/>
       <customer-name :is-confirm="true"/>
       <customer-phone-number :is-confirm="true"/>
+      <customer-adress v-if="false" :is-confirm="true"/>
       <customer-message :is-confirm="true"/>
       <fixed-btn />
     </div>

--- a/pages/mypage/profile/confirm.vue
+++ b/pages/mypage/profile/confirm.vue
@@ -9,8 +9,8 @@
 
     <h3><p class="under">会員情報変更</p></h3>
     <div class="pr">
+      <customer-mail :is-label="true"/>
       <customer-name :is-confirm="true"/>
-      <customer-mail :is-confirm="true"/>
       <customer-phone-number :is-confirm="true"/>
       <customer-message :is-confirm="true"/>
       <fixed-btn />

--- a/pages/mypage/profile/confirm.vue
+++ b/pages/mypage/profile/confirm.vue
@@ -9,7 +9,7 @@
 
     <h3><p class="under">会員情報変更</p></h3>
     <div class="pr">
-      <customer-mail :is-label="true"/>
+      <customer-mail :read-only="true"/>
       <customer-name :is-confirm="true"/>
       <customer-phone-number :is-confirm="true"/>
       <customer-adress v-if="false" :is-confirm="true"/>

--- a/pages/mypage/profile/confirm.vue
+++ b/pages/mypage/profile/confirm.vue
@@ -12,7 +12,6 @@
       <customer-name :is-confirm="true"/>
       <customer-mail :is-confirm="true"/>
       <customer-phone-number :is-confirm="true"/>
-      <customer-adress :is-confirm="true"/>
       <customer-message :is-confirm="true"/>
       <fixed-btn />
     </div>

--- a/pages/mypage/profile/edit.vue
+++ b/pages/mypage/profile/edit.vue
@@ -12,7 +12,7 @@
       <p class="under">会員情報変更</p>
     </h3>
     <div class="pr">
-      <customer-mail :is-label="true"/>
+      <customer-mail :read-only="true"/>
       <customer-name/>
       <customer-phone-number/>
       <customer-adress v-if="false"/>

--- a/pages/mypage/profile/edit.vue
+++ b/pages/mypage/profile/edit.vue
@@ -15,6 +15,7 @@
       <customer-mail :is-label="true"/>
       <customer-name/>
       <customer-phone-number/>
+      <customer-adress v-if="false"/>
       <customer-message/>
       <confirm-btn/>
     </div>
@@ -37,6 +38,7 @@ export default {
     CustomerMail,
     CustomerPhoneNumber,
     CustomerMessage,
+    CustomerAdress,
     ConfirmBtn
   },
   data: () => ({}),

--- a/pages/mypage/profile/edit.vue
+++ b/pages/mypage/profile/edit.vue
@@ -12,6 +12,7 @@
       <p class="under">会員情報変更</p>
     </h3>
     <div class="pr">
+      <customer-mail :is-label="true"/>
       <customer-name/>
       <customer-phone-number/>
       <customer-message/>

--- a/pages/mypage/profile/edit.vue
+++ b/pages/mypage/profile/edit.vue
@@ -14,7 +14,6 @@
     <div class="pr">
       <customer-name/>
       <customer-phone-number/>
-      <customer-adress/>
       <customer-message/>
       <confirm-btn/>
     </div>
@@ -37,7 +36,6 @@ export default {
     CustomerMail,
     CustomerPhoneNumber,
     CustomerMessage,
-    CustomerAdress,
     ConfirmBtn
   },
   data: () => ({}),

--- a/store/login.js
+++ b/store/login.js
@@ -15,7 +15,10 @@ const initialState = {
   mail2: '',
   phoneNumber: '',
   password: '',
-  password2: ''
+  password2: '',
+  postalCode: '',
+  prefecture: '',
+  city: ''
 }
 export const state = () =>
   Object.assign(
@@ -52,7 +55,10 @@ export const getters = {
       first_kana: state.firstNameKana,
       last_kana: state.lastNameKana,
       tel: state.phoneNumber,
-      can_receive_mail: rootGetters['registration/canReceiveMail']
+      can_receive_mail: rootGetters['registration/canReceiveMail'],
+      zip_code: state.postalCode,
+      prefecture: state.prefecture,
+      city: state.city
     }
   },
   createParams(state, getters, rootState) {
@@ -105,6 +111,15 @@ export const mutations = {
   setPassword2(state, password2) {
     state.password2 = password2
   },
+  setPostalCode(state, postalCode) {
+    state.postalCode = postalCode
+  },
+  setPrefecture(state, prefecture) {
+    state.prefecture = prefecture
+  },
+  setCity(state, city) {
+    state.city = city
+  },
   setError(state, errorMessage = '') {
     // stateを初期化
     state = Object.assign(state, initialState)
@@ -138,6 +153,9 @@ export const actions = {
     commit('setMail', customer.email)
     commit('setMail2', customer.email)
     commit('setPhoneNumber', customer.tel)
+    commit('setPostalCode', customer.zip_code)
+    commit('setPrefecture', customer.prefecture)
+    commit('setCity', customer.city)
 
     return customer
   },

--- a/store/login.js
+++ b/store/login.js
@@ -15,10 +15,7 @@ const initialState = {
   mail2: '',
   phoneNumber: '',
   password: '',
-  password2: '',
-  postalCode: '',
-  prefecture: '',
-  city: ''
+  password2: ''
 }
 export const state = () =>
   Object.assign(
@@ -55,10 +52,7 @@ export const getters = {
       first_kana: state.firstNameKana,
       last_kana: state.lastNameKana,
       tel: state.phoneNumber,
-      can_receive_mail: rootGetters['registration/canReceiveMail'],
-      zip_code: state.postalCode,
-      prefecture: state.prefecture,
-      city: state.city
+      can_receive_mail: rootGetters['registration/canReceiveMail']
     }
   },
   createParams(state, getters, rootState) {
@@ -111,15 +105,6 @@ export const mutations = {
   setPassword2(state, password2) {
     state.password2 = password2
   },
-  setPostalCode(state, postalCode) {
-    state.postalCode = postalCode
-  },
-  setPrefecture(state, prefecture) {
-    state.prefecture = prefecture
-  },
-  setCity(state, city) {
-    state.city = city
-  },
   setError(state, errorMessage = '') {
     // stateを初期化
     state = Object.assign(state, initialState)
@@ -153,9 +138,6 @@ export const actions = {
     commit('setMail', customer.email)
     commit('setMail2', customer.email)
     commit('setPhoneNumber', customer.tel)
-    commit('setPostalCode', customer.zip_code)
-    commit('setPrefecture', customer.prefecture)
-    commit('setCity', customer.city)
 
     return customer
   },


### PR DESCRIPTION
- 【マイページ】ボタンの表示を「キャンセル」→「キャンセルする」へ変更
- 【マイページ】「オリーヴボディケア店舗情報」のリンクが違う
- 【マイページ：会員情報変更】住所項目は削除する
- 【マイページ：お客様情報変更】メールアドレスを表示だけする（変更不可）