### PR TITLE
他コンポーネントのcssが他ページに影響あったので修正

### DIFF
--- a/components/pages/mypage/Coupon.vue
+++ b/components/pages/mypage/Coupon.vue
@@ -19,7 +19,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
 .v-card__title,
 .v-card__text {
   color: black;

--- a/components/pages/mypage/reservations/ReserveHistory.vue
+++ b/components/pages/mypage/reservations/ReserveHistory.vue
@@ -47,7 +47,7 @@ export default {
 }
 </script>
 
-<style>
+<style scoped>
 .v-card__title,
 .v-card__text {
   color: black;


### PR DESCRIPTION
* 【メニュー選択】他の画面からメニュー画面へ遷移してきたときだけ、ボタンやラベルの文字色が黒色になっていてcssが効いていない（リロードすると直る）
  * https://trello.com/c/uPr8qCLL