### PR TITLE
予約内のログイン画面に店舗IDがない件を修正

### DIFF
--- a/components/pages/login/Form.vue
+++ b/components/pages/login/Form.vue
@@ -44,6 +44,10 @@ export default {
     link: {
       type: String,
       default: ''
+    },
+    query: {
+      type: Object,
+      default: () => {}
     }
   },
   data: () => ({
@@ -71,7 +75,7 @@ export default {
         password: this.password
       }).then(isLogin => {
         if (isLogin) {
-          this.$router.push(this.link)
+          this.$router.push({ path: this.link, query: this.query })
         }
       })
     },

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -13,7 +13,7 @@
           <div>
             <h2 class="subtitle">会員の方はこちら</h2>
             <password-alert />
-            <login-form :link="link" />
+            <login-form :link="link" :query="query" />
             <nuxt-link to="/password/reset">
               パスワードを忘れた方はこちら
             </nuxt-link>
@@ -44,14 +44,18 @@ import PasswordAlert from '~/components/pages/common/PasswordAlert.vue'
 import { mapState, mapActions, mapMutations } from 'vuex'
 
 export default {
+  middleware: ['init-shop-id'],
   components: {
     LoginForm,
     Loading,
     PasswordAlert
   },
-  data: () => ({
-    link: '/registration'
-  }),
+  asyncData({ query }) {
+    return {
+      link: '/registration',
+      query: { shopId: query.shopId }
+    }
+  },
   computed: {
     ...mapState({
       login: state => state.login

--- a/pages/password/reset.vue
+++ b/pages/password/reset.vue
@@ -32,7 +32,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .input {
   width: 90%;
   margin: 0 auto;


### PR DESCRIPTION
# 対応内容
- ログイン画面を経由しても、getパラメータが消えないようにする