### PR TITLE
予約確定ボタンを連打できないようにする

### DIFF
--- a/components/pages/confirm/FixedBtn.vue
+++ b/components/pages/confirm/FixedBtn.vue
@@ -3,7 +3,7 @@
 
     <v-layout column>
       <v-flex xs6>
-        <v-btn color="warning" @click="fix">
+        <v-btn :disabled="pushed" color="warning" @click="fix">
           上記に同意の上予約を確定する
         </v-btn>
       </v-flex>
@@ -20,8 +20,14 @@
 
 <script>
 export default {
+  data() {
+    return {
+      pushed: false
+    }
+  },
   methods: {
     fix() {
+      this.pushed = true
       this.$router.push('/complete')
     },
     back() {


### PR DESCRIPTION
# 対応内容
- 連打防止できないようにする
- 予約枠にも関連するので、一旦予約確定ボタンのみ対応