### PR TITLE
マイページのボタン以外の挙動を消す

### DIFF
--- a/components/pages/mypage/reservations/ReserveData.vue
+++ b/components/pages/mypage/reservations/ReserveData.vue
@@ -3,7 +3,7 @@
     <div class="card-main cancel">
       <v-layout row>
         <v-flex xs5 class="text-menu">
-          <v-chip :color="reserveStateCss" label text-color="white">{{ data.state }}</v-chip>
+          <v-chip :color="reserveStateCss" label text-color="white" disabled>{{ data.state }}</v-chip>
         </v-flex>
         <v-flex xs6>
           <div class="text-value shop">{{ data.store.name }}</div>


### PR DESCRIPTION
## 概要
マイページでボタン以外をクリック or タップした際に挙動があるため完全に表示するのみにする

## trello
【マイページ】ボタンじゃないやつをクリックorタップすると若干の挙動があって紛らわしいので、完全に表示のみにする ( https://trello.com/c/VqOJiPms/259-【マイページ】ボタンじゃないやつをクリックorタップすると若干の挙動があって紛らわしいので、完全に表示のみにする )

## 確認してほしいところ
* 対応漏れがないか（そもそもこういうことなのか）