### PR TITLE
マイページのキャンセル一覧のレイアウト崩れを修正

### DIFF
--- a/components/pages/mypage/reservations/ReserveData.vue
+++ b/components/pages/mypage/reservations/ReserveData.vue
@@ -1,15 +1,26 @@
 <template>
-  <v-card color="white">
+  <v-card color="white pa-3">
     <div class="card-main cancel">
-      <v-layout row>
+      <v-layout row wrap>
         <v-flex xs5 class="text-menu">
           <v-chip :color="reserveStateCss" label text-color="white" disabled>{{ data.state }}</v-chip>
         </v-flex>
+        <v-flex v-if="isShownCancelButton" xs6 >
+          <v-btn
+            v-if="isShownCancelButton"
+            :disabled="canNotCancel"
+            class="cancel-btn d-inline-flex"
+            color="warning"
+            @click="cancelConfrim(data.id)"
+          >キャンセルする</v-btn>
+        </v-flex>
+      </v-layout>
+      <v-layout row wrap>
+        <v-flex xs5>
+          <div class="text-menu">予約店舗</div>
+        </v-flex>
         <v-flex xs6>
           <div class="text-value shop">{{ data.store.name }}</div>
-        </v-flex>
-        <v-flex v-if="isShownCancelButton" xs6 >
-          <v-btn :disabled="canNotCancel" class="cancel-btn" color="warning" @click="cancelConfrim(data.id)">キャンセルする</v-btn>
         </v-flex>
       </v-layout>
       <v-layout row wrap>
@@ -132,10 +143,8 @@ export default {
 </script>
 
 <style scoped>
-.cancel button .v-btn__content {
-  font-size: 1em;
-}
 .cancel-btn {
-  width: 150px;
+  width: 90%;
+  font-size: smaller;
 }
 </style>


### PR DESCRIPTION
## 概要
spのマイページのキャンセル一覧（`/mypage/reservations/?page=1&cancel=true`）のレイアウト崩れを修正

## Trello
[9/6追加]【FE】マイページのキャンセル一覧画面のレイアウト崩れを対応する ( https://trello.com/c/PPTqOam2/362-9-6%E8%BF%BD%E5%8A%A0%E3%80%90fe%E3%80%91%E3%83%9E%E3%82%A4%E3%83%9A%E3%83%BC%E3%82%B8%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%B3%E3%82%BB%E3%83%AB%E4%B8%80%E8%A6%A7%E7%94%BB%E9%9D%A2%E3%81%AE%E3%83%AC%E3%82%A4%E3%82%A2%E3%82%A6%E3%83%88%E5%B4%A9%E3%82%8C%E3%82%92%E5%AF%BE%E5%BF%9C%E3%81%99%E3%82%8B )

## 備考
* `予約店舗`という項目を増やしたが、この文言が正しいかどうか