### PR TITLE
エラーページの共通化

### DIFF
--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -84,7 +84,7 @@ export default {
       } else if (this.message && !this.isIncludedObjectString) {
         return this.message
       }
-      return 'ただいまサイトにアクセスできません。'
+      return 'エラーが発生しました。'
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -42,14 +42,18 @@ export default {
     message() {
       return this.error && this.error.message
     },
+    // messageにobjectの文字列が勝手に入っている場合があるので考慮
+    isIncludedObjectString() {
+      return /({|})/.test(this.message)
+    },
     errorMessage() {
       const statusCode = this.statusCode
       if (statusCode === 404) {
-        // 404はerror.messageにデフォルトの値が入っている場合があるので先に返す
+        // 404はerror.messageにデフォルトの文字列が入っている場合があるので先に返す
         return 'ページが見つかりません。'
       }
 
-      if (this.message) {
+      if (this.message && !this.isIncludedObjectString) {
         return this.message
       }
 
@@ -60,7 +64,9 @@ export default {
       return message
     },
     isShownDefaultErrorMessage() {
-      return !this.message || this.statusCode === 404
+      return (
+        !this.message || this.isIncludedObjectString || this.statusCode === 404
+      )
     },
     ...mapGetters('login', ['isLogin'])
   },

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -49,15 +49,14 @@ export default {
       return /({|})/.test(this.message)
     },
     errorMessage() {
-      let _message = this.getBaseErrorMessage()
+      const _message = this.getBaseErrorMessage()
 
-      if (this.isShownDefaultErrorMessage) {
-        _message +=
-          '<br>OSのバージョンアップをしていただくか、\
-          <a href="https://olivebodycare.healthcare/about/contact">こちら</a>\
-          のお問い合わせフォームからご予約をお願いいたします。'
-      }
-      return _message
+      if (!this.isShownDefaultErrorMessage) return _message
+
+      return `${_message}\
+        <br>OSのバージョンアップをしていただくか、\
+        <a href="https://olivebodycare.healthcare/about/contact">こちら</a>\
+        のお問い合わせフォームからご予約をお願いいたします。`
     },
     isShownDefaultErrorMessage() {
       return (
@@ -84,9 +83,8 @@ export default {
         return 'ページが見つかりません。'
       } else if (this.message && !this.isIncludedObjectString) {
         return this.message
-      } else if (/5\d{2}/.test(statusCode)) {
-        return 'ただいまサイトにアクセスできません。'
       }
+      return 'ただいまサイトにアクセスできません。'
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,9 +1,6 @@
 <template>
   <div class="container">
-    <div v-if="statusCode === 404">ページが見つかりません。</div>
-    <div v-else>
-      エラーです。<br>OSのバージョンアップをしていただくか、<a href="https://olivebodycare.healthcare/about/contact">こちら</a>のお問い合わせフォームからご予約をお願いいたします。
-    </div>
+    <div v-html="errorMessage"/>
     <br>
     <div>
       <nuxt-link to="/">ホーム</nuxt-link>に戻る。
@@ -27,6 +24,19 @@ export default {
   computed: {
     statusCode() {
       return (this.error && this.error.statusCode) || 500
+    },
+    errorMessage() {
+      const statusCode = this.statusCode
+      let message = `エラーです。<br>OSのバージョンアップをしていただくか、
+        <a href="https://olivebodycare.healthcare/about/contact">こちら</a>
+        のお問い合わせフォームからご予約をお願いいたします。`
+      if (statusCode === 404) {
+        message = 'ページが見つかりません。'
+      } else if (Math.floor(statusCode / 100) === 5) {
+        message = `ただいまサイトにアクセスできません。<br>
+          時間を置いて再度アクセスしてください。`
+      }
+      return message
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -4,12 +4,7 @@
       <v-layout column wrap>
         <v-layout row>
           <v-flex>
-            <v-card-text class="message">
-              {{ errorMessage }}
-              <template v-if="isShownDefaultErrorMessage">
-                <br>OSのバージョンアップをしていただくか、<a href="https://olivebodycare.healthcare/about/contact">こちら</a>のお問い合わせフォームからご予約をお願いいたします。
-              </template>
-            </v-card-text>
+            <v-card-text class="message" v-html="errorMessage" />
           </v-flex>
         </v-layout>
         <v-layout column>
@@ -55,20 +50,24 @@ export default {
     },
     errorMessage() {
       const statusCode = this.statusCode
+      let _message = ''
       if (statusCode === 404) {
         // 404はerror.messageにデフォルトの文字列が入っている場合があるので先に返す
-        return 'ページが見つかりません。'
+        _message += 'ページが見つかりません。'
+      } else if (this.message && !this.isIncludedObjectString) {
+        _message += this.message
+      } else if (/5\d{2}/.test(statusCode)) {
+        _message += 'ただいまサイトにアクセスできません。'
       }
 
-      if (this.message && !this.isIncludedObjectString) {
-        return this.message
+      if (this.isShownDefaultErrorMessage) {
+        _message +=
+          '<br>OSのバージョンアップをしていただくか、\
+          <a href="https://olivebodycare.healthcare/about/contact">こちら</a>\
+          のお問い合わせフォームからご予約をお願いいたします。'
       }
 
-      let message = 'エラーです。'
-      if (/5\d{2}/.test(statusCode)) {
-        message = 'ただいまサイトにアクセスできません。'
-      }
-      return message
+      return _message
     },
     isShownDefaultErrorMessage() {
       return (
@@ -96,6 +95,5 @@ export default {
 .message {
   color: red;
   font-weight: bolder;
-  white-space: pre-line;
 }
 </style>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -15,6 +15,9 @@
           <v-flex v-if="isLogin" xs6>
             <v-btn color="warning" @click="goMyPage">マイページへ</v-btn>
           </v-flex>
+          <v-flex xs6>
+            <v-btn color="warning" @click="back">戻る</v-btn>
+          </v-flex>
         </v-layout>
       </v-layout>
     </v-container>
@@ -76,6 +79,10 @@ export default {
     },
     goMyPage() {
       this.$router.push('/mypage')
+    },
+    back() {
+      // ブラウザバック
+      this.$router.go(-1)
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -49,16 +49,7 @@ export default {
       return /({|})/.test(this.message)
     },
     errorMessage() {
-      const statusCode = this.statusCode
-      let _message = ''
-      if (statusCode === 404) {
-        // 404はerror.messageにデフォルトの文字列が入っている場合があるので先に返す
-        _message += 'ページが見つかりません。'
-      } else if (this.message && !this.isIncludedObjectString) {
-        _message += this.message
-      } else if (/5\d{2}/.test(statusCode)) {
-        _message += 'ただいまサイトにアクセスできません。'
-      }
+      let _message = this.getBaseErrorMessage()
 
       if (this.isShownDefaultErrorMessage) {
         _message +=
@@ -66,7 +57,6 @@ export default {
           <a href="https://olivebodycare.healthcare/about/contact">こちら</a>\
           のお問い合わせフォームからご予約をお願いいたします。'
       }
-
       return _message
     },
     isShownDefaultErrorMessage() {
@@ -86,6 +76,17 @@ export default {
     back() {
       // ブラウザバック
       this.$router.go(-1)
+    },
+    getBaseErrorMessage() {
+      const statusCode = this.statusCode
+      if (statusCode === 404) {
+        // 404はerror.messageにデフォルトの文字列が入っている場合があるので先に返す
+        return 'ページが見つかりません。'
+      } else if (this.message && !this.isIncludedObjectString) {
+        return this.message
+      } else if (/5\d{2}/.test(statusCode)) {
+        return 'ただいまサイトにアクセスできません。'
+      }
     }
   }
 }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,14 +1,28 @@
 <template>
-  <div class="container">
-    <div v-html="errorMessage"/>
-    <br>
-    <div>
-      <nuxt-link to="/">ホーム</nuxt-link>に戻る。
-    </div>
-  </div>
+  <section class="container">
+    <v-container grid-list-xl>
+      <v-layout column wrap>
+        <v-layout row>
+          <v-flex>
+            <v-card-text class="message">{{ errorMessage }}<template v-if="isShownDefaultErrorMessage"><br>OSのバージョンアップをしていただくか、<a href="https://olivebodycare.healthcare/about/contact">こちら</a>のお問い合わせフォームからご予約をお願いいたします。</template>
+            </v-card-text>
+          </v-flex>
+        </v-layout>
+        <v-layout column>
+          <v-flex xs6>
+            <v-btn color="warning" href="https://olivebodycare.healthcare/">店舗ホームページへ</v-btn>
+          </v-flex>
+          <v-flex v-if="isLogin" xs6>
+            <v-btn color="warning" @click="goMyPage">マイページへ</v-btn>
+          </v-flex>
+        </v-layout>
+      </v-layout>
+    </v-container>
+  </section>
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 export default {
   props: {
     error: {
@@ -23,26 +37,48 @@ export default {
   },
   computed: {
     statusCode() {
-      return (this.error && this.error.statusCode) || 500
+      return this.error && this.error.statusCode
+    },
+    message() {
+      return this.error && this.error.message
     },
     errorMessage() {
       const statusCode = this.statusCode
-      let message = `エラーです。<br>OSのバージョンアップをしていただくか、
-        <a href="https://olivebodycare.healthcare/about/contact">こちら</a>
-        のお問い合わせフォームからご予約をお願いいたします。`
       if (statusCode === 404) {
-        message = 'ページが見つかりません。'
-      } else if (Math.floor(statusCode / 100) === 5) {
-        message = `ただいまサイトにアクセスできません。<br>
-          時間を置いて再度アクセスしてください。`
+        // 404はerror.messageにデフォルトの値が入っている場合があるので先に返す
+        return 'ページが見つかりません。'
+      }
+
+      if (this.message) {
+        return this.message
+      }
+
+      let message = 'エラーです。'
+      if (Math.floor(statusCode / 100) === 5) {
+        message = 'ただいまサイトにアクセスできません。'
       }
       return message
+    },
+    isShownDefaultErrorMessage() {
+      return !this.message || this.statusCode === 404
+    },
+    ...mapGetters('login', ['isLogin'])
+  },
+  methods: {
+    goHomePage() {
+      this.$router.push('/')
+    },
+    goMyPage() {
+      this.$router.push('/mypage')
     }
   }
 }
 </script>
+
 <style scoped>
-.container {
-  flex-direction: column;
+.message {
+  color: red;
+  font-weight: bolder;
+  white-space: pre-wrap;
 }
 </style>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -65,7 +65,7 @@ export default {
       }
 
       let message = 'エラーです。'
-      if (Math.floor(statusCode / 100) === 5) {
+      if (/5\d{2}/.test(statusCode)) {
         message = 'ただいまサイトにアクセスできません。'
       }
       return message

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -4,7 +4,11 @@
       <v-layout column wrap>
         <v-layout row>
           <v-flex>
-            <v-card-text class="message">{{ errorMessage }}<template v-if="isShownDefaultErrorMessage"><br>OSのバージョンアップをしていただくか、<a href="https://olivebodycare.healthcare/about/contact">こちら</a>のお問い合わせフォームからご予約をお願いいたします。</template>
+            <v-card-text class="message">
+              {{ errorMessage }}
+              <template v-if="isShownDefaultErrorMessage">
+                <br>OSのバージョンアップをしていただくか、<a href="https://olivebodycare.healthcare/about/contact">こちら</a>のお問い合わせフォームからご予約をお願いいたします。
+              </template>
             </v-card-text>
           </v-flex>
         </v-layout>
@@ -92,6 +96,6 @@ export default {
 .message {
   color: red;
   font-weight: bolder;
-  white-space: pre-wrap;
+  white-space: pre-line;
 }
 </style>

--- a/middleware/fetch-reservations.js
+++ b/middleware/fetch-reservations.js
@@ -1,7 +1,11 @@
-export default function({ store, query }) {
-  const doCancel = 'cancel' in query ? Boolean(query.cancel) : false
-  store.commit('reservation/setDoCancel', doCancel)
+export default async function({ store, query, error }) {
+  try {
+    const doCancel = 'cancel' in query ? Boolean(query.cancel) : false
+    store.commit('reservation/setDoCancel', doCancel)
 
-  const page = 'page' in query ? query.page : 1
-  store.dispatch('reservation/getReservations', page)
+    const page = 'page' in query ? query.page : 1
+    await store.dispatch('reservation/getReservations', page)
+  } catch (e) {
+    error({ statusCode: (e.response && e.response.status) || 500 })
+  }
 }

--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -59,7 +59,7 @@ export default {
         statusCode: 500,
         message: `${
           registration.errorMessage
-        }\nお手数ですが、再度ご予約の操作をお願いいたします。`
+        }<br>お手数ですが、再度ご予約の操作をお願いいたします。`
       })
     }
 
@@ -69,7 +69,7 @@ export default {
         statusCode: 401,
         message: `${
           login.errorMessage
-        }\nお手数ですが最初からやり直してください。`
+        }<br>お手数ですが最初からやり直してください。`
       })
     }
   },

--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -69,10 +69,7 @@ export default {
         })
       }
     } catch (e) {
-      error({
-        statusCode: (e.response && e.response.status) || 500,
-        message: ''
-      })
+      error({ statusCode: (e.response && e.response.status) || 500 })
     }
   },
   methods: {

--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -49,27 +49,28 @@ export default {
       const result = await store.dispatch(
         'reservation/registration/registerCustomerWithReserve'
       )
-
-      const { registration } = store.state.reservation
-      if (registration.isError) {
-        error({
-          statusCode: 500,
-          message:
-            registration.errorMessage +
-            '\nお手数ですが、再度ご予約の操作をお願いいたします。'
-        })
-      }
-
-      const { login } = store.state
-      if (login.isError) {
-        error({
-          statusCode: 401,
-          message:
-            login.errorMessage + '\nお手数ですが最初からやり直してください。'
-        })
-      }
     } catch (e) {
       error({ statusCode: (e.response && e.response.status) || 500 })
+    }
+
+    const { registration } = store.state.reservation
+    if (registration.isError) {
+      error({
+        statusCode: 500,
+        message: `${
+          registration.errorMessage
+        }\nお手数ですが、再度ご予約の操作をお願いいたします。`
+      })
+    }
+
+    const { login } = store.state
+    if (login.isError) {
+      error({
+        statusCode: 401,
+        message: `${
+          login.errorMessage
+        }\nお手数ですが最初からやり直してください。`
+      })
     }
   },
   methods: {

--- a/pages/create/complete.vue
+++ b/pages/create/complete.vue
@@ -10,17 +10,11 @@
           </v-card>
         </v-flex>
 
-        <template v-if="isError">
-          <div>{{ errorMessage }}お手数ですが、最初からやり直してください。</div>
-        </template>
-        <template v-else>
-          <div>会員登録が完了しました</div>
-        </template>
+        <div>会員登録が完了しました</div>
 
         <v-layout column>
           <v-flex xs6>
-            <v-btn v-if="isError" @click="back">戻る</v-btn>
-            <v-btn v-else @click="login">ログイン</v-btn>
+            <v-btn @click="login">ログイン</v-btn>
           </v-flex>
         </v-layout>
       </v-layout>
@@ -29,28 +23,28 @@
 </template>
 
 <script>
-import { mapActions, mapMutations, mapState } from 'vuex'
-
 export default {
-  computed: {
-    ...mapState('login', ['isError', 'errorMessage'])
-  },
-  created() {
-    // 会員登録させるため、isCreateをtrueにする
-    this.setIsCreate(true)
-    this.createCustomer()
-    this.reset()
+  async fetch({ store, error }) {
+    try {
+      // 会員登録させるため、isCreateをtrueにする
+      store.commit('login/setIsCreate', true)
+      await store.dispatch('login/createCustomer')
+
+      const { login } = store.state
+      if (login.isError) {
+        const message =
+          login.errorMessage + '\nお手数ですが最初からやり直してください。'
+        store.commit('login/reset')
+        error({ statusCode: 401, message })
+      }
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   },
   methods: {
     login() {
       this.$router.push('/mypage/login')
-    },
-    back() {
-      this.reset()
-      this.$router.push('/create')
-    },
-    ...mapActions('login', ['createCustomer']),
-    ...mapMutations('login', ['setIsCreate', 'reset', 'resetCustomerInfo'])
+    }
   }
 }
 </script>

--- a/pages/create/complete.vue
+++ b/pages/create/complete.vue
@@ -37,7 +37,7 @@ export default {
     if (login.isError) {
       const message = `${
         login.errorMessage
-      }\nお手数ですが最初からやり直してください。`
+      }<br>お手数ですが最初からやり直してください。`
       store.commit('login/reset')
       error({ statusCode: 400, message })
     }

--- a/pages/create/complete.vue
+++ b/pages/create/complete.vue
@@ -35,7 +35,7 @@ export default {
         const message =
           login.errorMessage + '\nお手数ですが最初からやり直してください。'
         store.commit('login/reset')
-        error({ statusCode: 401, message })
+        error({ statusCode: 400, message })
       }
     } catch (e) {
       error({ statusCode: (e.response && e.response.status) || 500 })

--- a/pages/create/complete.vue
+++ b/pages/create/complete.vue
@@ -29,16 +29,17 @@ export default {
       // 会員登録させるため、isCreateをtrueにする
       store.commit('login/setIsCreate', true)
       await store.dispatch('login/createCustomer')
-
-      const { login } = store.state
-      if (login.isError) {
-        const message =
-          login.errorMessage + '\nお手数ですが最初からやり直してください。'
-        store.commit('login/reset')
-        error({ statusCode: 400, message })
-      }
     } catch (e) {
       error({ statusCode: (e.response && e.response.status) || 500 })
+    }
+
+    const { login } = store.state
+    if (login.isError) {
+      const message = `${
+        login.errorMessage
+      }\nお手数ですが最初からやり直してください。`
+      store.commit('login/reset')
+      error({ statusCode: 400, message })
     }
   },
   methods: {

--- a/pages/date/index.vue
+++ b/pages/date/index.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { mapActions, mapState, mapMutations, mapGetters } from 'vuex'
+import { mapGetters } from 'vuex'
 import RegistrationMenu from '~/components/pages/common/RegistrationMenu.vue'
 import Calendar from '~/components/pages/date/Calendar.vue'
 import BackBtn from '~/components/pages/date/BackBtn.vue'
@@ -31,11 +31,12 @@ export default {
   computed: {
     ...mapGetters('reservation/date', ['isLoading'])
   },
-  created() {
-    this.getCalendar()
-  },
-  methods: {
-    ...mapActions('reservation/date', ['getCalendar'])
+  async fetch({ store, error }) {
+    try {
+      await store.dispatch('reservation/date/getCalendar')
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   }
 }
 </script>

--- a/pages/menus/index.vue
+++ b/pages/menus/index.vue
@@ -31,11 +31,17 @@ import CustomerMustUpdateError from '~/components/pages/common/CustomerMustUpdat
 export default {
   middleware: ['init-menu-index', 'init-shop-id'],
   watchQuery: ['shopId'],
-  fetch({ store, query }) {
-    // shopIdがnullの場合は1をセットする
-    const shopId = query.shopId || 1
-    store.dispatch('shop/getShop', { id: shopId })
-    store.dispatch('menu/getMenus', { shopId })
+  async fetch({ store, query, error }) {
+    try {
+      // shopIdがnullの場合は1をセットする
+      const shopId = query.shopId || 1
+      await Promise.all([
+        store.dispatch('shop/getShop', { id: shopId }),
+        store.dispatch('menu/getMenus', { shopId })
+      ])
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   },
   components: {
     MenuList,

--- a/pages/mypage/profile/complete.vue
+++ b/pages/mypage/profile/complete.vue
@@ -27,7 +27,7 @@ export default {
     if (login.isError) {
       const message = `${
         login.errorMessage
-      }\nお手数ですが最初からやり直してください。`
+      }<br>お手数ですが最初からやり直してください。`
       store.commit('login/reset')
       error({ statusCode: 400, message })
     }

--- a/pages/mypage/profile/complete.vue
+++ b/pages/mypage/profile/complete.vue
@@ -19,16 +19,17 @@ export default {
   async fetch({ store, error }) {
     try {
       await store.dispatch('login/updateCustomer')
-
-      const { login } = store.state
-      if (login.isError) {
-        const message =
-          login.errorMessage + '\nお手数ですが最初からやり直してください。'
-        store.commit('login/reset')
-        error({ statusCode: 400, message })
-      }
     } catch (e) {
       error({ statusCode: (e.response && e.response.status) || 500 })
+    }
+
+    const { login } = store.state
+    if (login.isError) {
+      const message = `${
+        login.errorMessage
+      }\nお手数ですが最初からやり直してください。`
+      store.commit('login/reset')
+      error({ statusCode: 400, message })
     }
   },
   methods: {

--- a/pages/mypage/profile/complete.vue
+++ b/pages/mypage/profile/complete.vue
@@ -8,30 +8,33 @@
       </v-card>
     </v-flex>
 
-    <div v-if="isError">{{ errorMessage }}お手数ですが、もう一度やり直しください。</div>
-    <div v-else>会員情報の変更が完了しました</div>
+    <div>会員情報の変更が完了しました</div>
     <v-btn color="warning" @click="goMypageTop">マイページトップへ</v-btn>
   </div>
 </template>
 
 <script>
-import { mapState, mapActions, mapMutations } from 'vuex'
-
 export default {
   layout: 'mypage',
-  computed: {
-    ...mapState('login', ['errorMessage', 'isError'])
-  },
-  created() {
-    this.updateCustomer()
-    this.reset()
+  async fetch({ store, error }) {
+    try {
+      await store.dispatch('login/updateCustomer')
+
+      const { login } = store.state
+      if (login.isError) {
+        const message =
+          login.errorMessage + '\nお手数ですが最初からやり直してください。'
+        store.commit('login/reset')
+        error({ statusCode: 400, message })
+      }
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   },
   methods: {
     goMypageTop() {
       this.$router.push('/mypage')
-    },
-    ...mapActions('login', ['updateCustomer']),
-    ...mapMutations('login', ['reset'])
+    }
   }
 }
 </script>

--- a/pages/mypage/reservations/cancel/complete.vue
+++ b/pages/mypage/reservations/cancel/complete.vue
@@ -7,14 +7,8 @@
       </v-card>
     </v-flex>
 
-    <template v-if="result">
-      <div>予約をキャンセルしました。</div>
-      <div>予約キャンセルメールをお送りしましたので、ご確認ください。</div>
-    </template>
-
-    <template v-else>
-      <div>エラーが発生しました。お手数ですが、もう一度やり直してください。</div>
-    </template>
+    <div>予約をキャンセルしました。</div>
+    <div>予約キャンセルメールをお送りしましたので、ご確認ください。</div>
 
     <v-flex>
       <v-btn color="warning" @click="top">マイページトップへ</v-btn>
@@ -26,13 +20,16 @@
 <script>
 export default {
   layout: 'mypage',
-  async asyncData({ store, query }) {
-    const result = await store.dispatch(
-      'reservation/destroyReservation',
-      query.id
-    )
-
-    return { result }
+  async fetch({ store, query, error }) {
+    try {
+      await store.dispatch('reservation/destroyReservation', query.id)
+    } catch (e) {
+      error({
+        statusCode: (e.response && e.response.status) || 500,
+        message:
+          'エラーが発生しました。お手数ですが、もう一度やり直してください。'
+      })
+    }
   },
   methods: {
     top() {

--- a/pages/mypage/reservations/cancel/index.vue
+++ b/pages/mypage/reservations/cancel/index.vue
@@ -26,20 +26,20 @@ export default {
   async fetch({ store, query, error }) {
     try {
       await store.dispatch('reservation/getReservation', query.id)
-
-      const { reservations } = store.state.reservation
-      if (!reservations.length) {
-        error({
-          statusCode: 400,
-          message:
-            'エラーが発生しました。お手数ですが、もう一度やりなおしてください。'
-        })
-      }
     } catch (e) {
       error({
         statusCode: (e.response && e.response.status) || 500,
         message:
           'エラーが発生しました。お手数ですが、もう一度やり直してください。'
+      })
+    }
+
+    const { reservations } = store.state.reservation
+    if (!reservations.length) {
+      error({
+        statusCode: 400,
+        message:
+          'エラーが発生しました。お手数ですが、もう一度やりなおしてください。'
       })
     }
   },

--- a/pages/mypage/reservations/cancel/index.vue
+++ b/pages/mypage/reservations/cancel/index.vue
@@ -7,46 +7,44 @@
       </v-card>
     </v-flex>
 
-    <template v-if="isShownHisroty">
-      <mypage-reserve-history　:force-hide-cancel="true" />
+    <mypage-reserve-history　:force-hide-cancel="true" />
 
-      <div class="message">予約をキャンセルします。よろしいですか？</div>
-      <v-flex>
-        <v-btn @click="back">戻る</v-btn>
-        <v-btn color="warning" @click="complete">確定する</v-btn>
-      </v-flex>
-    </template>
-    <template v-else>
-      <v-layout justify-center column>
-        <v-flex xs6>
-          <div>エラーが発生しました。お手数ですが、もう一度やりなおしてください。</div>
-        </v-flex>
-      </v-layout>
-      <v-flex>
-        <v-btn @click="back">戻る</v-btn>
-      </v-flex>
-    </template>
+    <div class="message">予約をキャンセルします。よろしいですか？</div>
+    <v-flex>
+      <v-btn @click="back">戻る</v-btn>
+      <v-btn color="warning" @click="complete">確定する</v-btn>
+    </v-flex>
 
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex'
 import MypageReserveHistory from '~/components/pages/mypage/reservations/ReserveHistory.vue'
 
 export default {
   layout: 'mypage',
-  fetch({ store, query }) {
-    store.dispatch('reservation/getReservation', query.id)
+  async fetch({ store, query, error }) {
+    try {
+      await store.dispatch('reservation/getReservation', query.id)
+
+      const { reservations } = store.state.reservation
+      if (!reservations.length) {
+        error({
+          statusCode: 400,
+          message:
+            'エラーが発生しました。お手数ですが、もう一度やりなおしてください。'
+        })
+      }
+    } catch (e) {
+      error({
+        statusCode: (e.response && e.response.status) || 500,
+        message:
+          'エラーが発生しました。お手数ですが、もう一度やり直してください。'
+      })
+    }
   },
   components: {
     MypageReserveHistory
-  },
-  computed: {
-    isShownHisroty() {
-      return this.reservations.length > 0
-    },
-    ...mapState('reservation', ['reservations'])
   },
   methods: {
     complete() {
@@ -54,10 +52,6 @@ export default {
         name: 'mypage-reservations-cancel-complete',
         query: { id: this.$route.query.id }
       })
-    },
-    back() {
-      // ブラウザバック
-      this.$router.go(-1)
     }
   }
 }

--- a/pages/password/complete.vue
+++ b/pages/password/complete.vue
@@ -14,14 +14,17 @@ import { mapActions } from 'vuex'
 
 export default {
   layout: 'password',
-  created() {
-    this.updatePassword()
+  async fetch({ store, error }) {
+    try {
+      await store.dispatch('login/updatePassword')
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   },
   methods: {
     login() {
       this.$router.push('/mypage')
-    },
-    ...mapActions('login', ['updatePassword'])
+    }
   }
 }
 </script>

--- a/pages/password/mail.vue
+++ b/pages/password/mail.vue
@@ -13,18 +13,19 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex'
-
 export default {
   layout: 'password',
-  created() {
-    this.sendPasswrodResetMail()
+  async fetch({ store, error }) {
+    try {
+      await store.dispatch('login/sendPasswrodResetMail')
+    } catch (e) {
+      error({ statusCode: (e.response && e.response.status) || 500 })
+    }
   },
   methods: {
     top() {
       this.$router.push('/mypage')
-    },
-    ...mapActions('login', ['sendPasswrodResetMail'])
+    }
   }
 }
 </script>

--- a/store/login.js
+++ b/store/login.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import get from 'lodash/get'
 
 /* state */
 const initialState = {
@@ -202,9 +203,8 @@ export const actions = {
       dispatch('setLoginCustomer', result.data.data)
       return true
     } catch (error) {
-      console.log(error)
       const errorMessage =
-        error.response.status === 422
+        get(error, 'response.status') === 422
           ? '登録済みのメールアドレスです。'
           : 'ユーザー作成に失敗しました。'
       commit('setError', errorMessage)

--- a/store/login.js
+++ b/store/login.js
@@ -203,6 +203,7 @@ export const actions = {
       dispatch('setLoginCustomer', result.data.data)
       return true
     } catch (error) {
+      console.log(error)
       const errorMessage =
         get(error, 'response.status') === 422
           ? '登録済みのメールアドレスです。'

--- a/store/reservation/index.js
+++ b/store/reservation/index.js
@@ -56,11 +56,7 @@ export const actions = {
     const authenticatedApi = rootGetters['login/authenticatedApi']
     const reservationPath = route(process.env.api.reservation, { id })
 
-    try {
-      await authenticatedApi.delete(reservationPath)
-      return true
-    } catch (e) {
-      return false
-    }
+    await authenticatedApi.delete(reservationPath)
+    return true
   }
 }


### PR DESCRIPTION
## 概要
エラーメッセージを表示するエラーページを共通化する

## Trello
【FE】エラーメッセージのリファクタリング ( https://trello.com/c/TZSf6X0k )

## 修正内容
* `/layouts/error.vue`を修正し、共通のエラーページとして利用
* `/pages`以下でAPIなどエラーがあった際にエラーページへ飛ばすよう修正
* `beforeCreate`や`created`などでAPIの処理が行われている箇所は`fetch`に置き換え

## 備考
* 共通化に伴い、それぞれのページで最適化されていたエラー表示部分（ボタンやレイアウト）を削ってしまっています。問題がないかどうかご確認ください。
* いろいろいじったのでお手数ですが不具合がないかご確認をお願いいたします（一応自分でも確認はしましたが）