### PR TITLE
キャンセル画面：戻るが機能しないバグの修正

### DIFF
--- a/pages/mypage/reservations/cancel/index.vue
+++ b/pages/mypage/reservations/cancel/index.vue
@@ -47,6 +47,9 @@ export default {
     MypageReserveHistory
   },
   methods: {
+    back() {
+      this.$router.go(-1)
+    },
     complete() {
       this.$router.push({
         name: 'mypage-reservations-cancel-complete',


### PR DESCRIPTION
# 対応内容
- 戻るボタンが機能しないバグの修正
    - リファクタリング時に消えていたので、再実装