### PR TITLE
ミドルウェア周りの修正

### DIFF
--- a/middleware/clear-selected-query.js
+++ b/middleware/clear-selected-query.js
@@ -1,0 +1,13 @@
+export default function({ store, query, redirect }) {
+  if (!store.getters['reservation/select/isMenuSelected']) {
+    redirect('/menus/', { shopId: query.shopId })
+  }
+
+  if (!store.getters['reservation/select/isDateTimeSelected']) {
+    redirect('/date/', { shopId: query.shopId, menus: query.menus })
+  }
+
+  if ('menus' in query || 'storeId' in query || 'dateTime' in query) {
+    redirect('/complete/', { shopId: query.shopId })
+  }
+}

--- a/middleware/date-time-selected.js
+++ b/middleware/date-time-selected.js
@@ -1,5 +1,0 @@
-export default function({ store, query, redirect }) {
-  if (!store.getters['reservation/select/isDateTimeSelected']) {
-    redirect('/menus/', { shopId: query.shopId })
-  }
-}

--- a/middleware/fetch-menus-from-query.js
+++ b/middleware/fetch-menus-from-query.js
@@ -7,7 +7,9 @@ export default async function({ store, error, redirect, query }) {
 
   try {
     // queryの情報を使ってメニューを取得
-    await store.dispatch('menu/getMenus', { shopId })
+    if (!store.getters['menu/hasSubShops']) {
+      await store.dispatch('menu/getMenus', { shopId })
+    }
   } catch (e) {
     error({ statusCode: (e.response && e.response.status) || 500 })
   }

--- a/middleware/fetch-menus-from-query.js
+++ b/middleware/fetch-menus-from-query.js
@@ -2,21 +2,18 @@ export default async function({ store, error, redirect, query }) {
   const { shopId, storeId, menus: menusQuery } = query
   const menusQueryArr = _parseMenusQuery(menusQuery)
   if (!storeId || !Array.isArray(menusQueryArr) || !menusQueryArr.length) {
-    redirect('/menus/')
+    return redirect('/menus/', { shopId })
   }
 
-  try {
-    // queryの情報を使ってメニューを取得
-    if (!store.getters['menu/hasSubShops']) {
-      await store.dispatch('menu/getMenus', { shopId })
-    }
-  } catch (e) {
-    error({ statusCode: (e.response && e.response.status) || 500 })
+  if (!store.getters['menu/hasSubShops']) {
+    await _dispatchGetMenus(store, shopId, error)
   }
+
   const allMenus = store.getters['menu/allMenus']
   const menus = allMenus
     .map(menu => _createMenu(menu, menusQueryArr))
     .filter(menu => menu)
+
   // 値をセット
   store.commit('reservation/select/setMenus', {
     menus,
@@ -25,19 +22,30 @@ export default async function({ store, error, redirect, query }) {
 }
 
 function _parseMenusQuery(menusQuery) {
-  let result
   try {
-    result = JSON.parse(menusQuery)
-  } catch (e) {}
+    return JSON.parse(menusQuery)
+  } catch (e) {
+    return null
+  }
+}
 
-  return result
+async function _dispatchGetMenus(store, shopId, error) {
+  try {
+    // queryの情報を使ってメニューを取得
+    await store.dispatch('menu/getMenus', { shopId })
+  } catch (e) {
+    error({ statusCode: (e.response && e.response.status) || 500 })
+  }
 }
 
 function _createMenu(menu, menusQueryArr) {
   const _menu = menusQueryArr.find(
     queryMenu => parseInt(menu.id) === parseInt(queryMenu.menuId)
   )
-  if (!_menu) return null
+
+  if (!_menu || _menu === undefined) {
+    return null
+  }
 
   const _optionIds = _menu.optionIds ? _menu.optionIds.split(',') : null
   let options = []

--- a/middleware/is-registered.js
+++ b/middleware/is-registered.js
@@ -7,9 +7,10 @@ export default ({ store, query, redirect }) => {
     !store.state.login.lastNameKana ||
     !store.state.login.mail ||
     !store.state.login.mail2 ||
-    !store.state.login.phoneNumber
+    !store.state.login.phoneNumber ||
+    !store.state.reservation.registration.isOk
   ) {
     // 登録画面にリダイレクトさせる
-    return redirect('/registration/', { shopId: query.shopId })
+    return redirect('/registration/', { ...query })
   }
 }

--- a/middleware/maintenance-redirector.js
+++ b/middleware/maintenance-redirector.js
@@ -1,14 +1,14 @@
-const matenancePath = '/maintenance/'
+const maintenancePath = '/maintenance/'
 
 export default function({ route, redirect }) {
   const isMaintenance = process.env.isMaintenance
-  const isMaintenancePath = route.path === matenancePath
+  const isMaintenancePath = route.path === maintenancePath
 
   if (!isMaintenance && isMaintenancePath) {
     redirect('/')
   }
 
   if (isMaintenance && !isMaintenancePath) {
-    redirect(matenancePath)
+    redirect(maintenancePath)
   }
 }

--- a/middleware/menu-selected.js
+++ b/middleware/menu-selected.js
@@ -1,5 +1,0 @@
-export default function({ store, query, redirect }) {
-  if (!store.getters['reservation/select/isMenuSelected']) {
-    redirect('/menus/', { shopId: query.shopId })
-  }
-}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -109,8 +109,8 @@ module.exports = {
   router: {
     middleware: [
       'validate-autenticates',
-      'mantenance-redirector',
-      'add-trailing-slash'
+      'add-trailing-slash',
+      'maintenance-redirector',
     ]
   }
 }

--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -30,12 +30,7 @@ export default {
   components: {
     NextBtn
   },
-  middleware: [
-    'menu-selected',
-    'date-time-selected',
-    'is-registered',
-    'init-shop-id'
-  ],
+  middleware: ['clear-selected-query', 'init-shop-id', 'is-registered'],
   computed: {
     registration() {
       return this.$store.state.reservation.registration

--- a/pages/confirm/index.vue
+++ b/pages/confirm/index.vue
@@ -29,10 +29,10 @@ import FixedBtn from '~/components/pages/confirm/FixedBtn.vue'
 
 export default {
   middleware: [
-    'menu-selected',
-    'date-time-selected',
-    'is-registered',
-    'init-shop-id'
+    'init-shop-id',
+    'fetch-menus-from-query',
+    'set-date-time-from-query',
+    'is-registered'
   ],
   components: {
     RegistrationUserInfo,

--- a/pages/maintenance.vue
+++ b/pages/maintenance.vue
@@ -11,3 +11,9 @@
     </v-container>
   </section>
 </template>
+
+<script>
+export default {
+  middleware: ['maintenance-redirector']
+}
+</script>

--- a/store/menu.js
+++ b/store/menu.js
@@ -15,7 +15,6 @@ export const mutations = {
 
 /* actions */
 export const actions = {
-  // ログインチェック
   async getMenus({ commit }, { shopId }) {
     const getShopMenuRoute = route(process.env.api.menu, { id: shopId })
     const response = await axios.get(getShopMenuRoute)

--- a/store/reservation/select.js
+++ b/store/reservation/select.js
@@ -66,7 +66,7 @@ export const mutations = {
   },
   setMenus(state, { menus, storeId }) {
     state.menus = menus
-    state.menuIndex = menus.length - 1
+    state.menuIndex = menus.length === 0 ? 0 : menus.length - 1
     state.storeId = storeId
   }
 }


### PR DESCRIPTION
# 対応内容
## ミドルウェアの追加
- 完了画面で再読み込みしても、予約が追加されないよう修正
- 確認画面で再読み込み時に、登録画面にリダイレクトするよう修正
- menusの取得処理が再読み込み時にのみ動作するよう修正
- 登録済みのチェックに、isOkを含める
- メンテナンスの綴りミスの修正
- 手動でクエリパラメータを削除しても、エラーにならないよう修正