### PR TITLE
非会員予約をできないようにする

### DIFF
--- a/components/pages/login/Form.vue
+++ b/components/pages/login/Form.vue
@@ -22,7 +22,8 @@
                icon="warning"
                outline
       >
-        メールアドレスもしくはパスワードが違います。
+        メールアドレスもしくはパスワードが違います。<br>
+        <nuxt-link to="/password/reset">パスワードを忘れた方はこちら</nuxt-link>
       </v-alert>
       <v-btn
         :disabled="!canLogin"

--- a/components/pages/login/Form.vue
+++ b/components/pages/login/Form.vue
@@ -16,7 +16,7 @@
         label="パスワード"
         @click:append="show = !show"
       />
-      <v-alert v-if="data.isError"
+      <v-alert v-if="errorMessage"
                :value="true"
                color="error"
                icon="warning"
@@ -52,7 +52,6 @@ export default {
   },
   data: () => ({
     show: false,
-    isError: false,
     mail: '',
     password: '',
     mailRules: [mail => checkMail(mail)],
@@ -64,7 +63,7 @@ export default {
         checkMail(this.mail) === true && checkPassword(this.password) === true
       )
     },
-    ...mapState({ data: 'user' })
+    ...mapState('user', ['errorMessage'])
   },
   methods: {
     // ログインボタンを押した時の動き

--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -59,7 +59,7 @@ export default {
     if (isUserError) {
       error({
         statusCode: 401,
-        message: `${userErrorMessage}<br>お手数ですが最初からやり直してください。`
+        message: `${userErrorMessage}<br>お手数ですが最初からやり直してください。<br>※ 会員登録をせずに<a href="https://olivebodycare.healthcare/about/contact/">こちら</a>からご予約いただくことも可能です。`
       })
     }
   },

--- a/pages/create/complete.vue
+++ b/pages/create/complete.vue
@@ -36,7 +36,7 @@ export default {
     const { errorMessage } = store.state.user
     const isError = store.getters['user/isError']
     if (isError) {
-      const message = `${errorMessage}<br>お手数ですが最初からやり直してください。`
+      const message = `${errorMessage}<br>お手数ですが最初からやり直してください。<br>※ 会員登録をせずに<a href="https://olivebodycare.healthcare/about/contact/">こちら</a>からご予約いただくことも可能です。`
       store.commit('user/reset')
       error({ statusCode: 400, message })
     }

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -13,7 +13,7 @@
           <div>
             <h2 class="subtitle">会員の方はこちら</h2>
             <login-form :link="link" :query="query" />
-            <nuxt-link to="/password/reset">
+            <nuxt-link v-if="!user.errorMessage" to="/password/reset">
               パスワードを忘れた方はこちら
             </nuxt-link>
           </div>

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -19,10 +19,9 @@
           </div>
 
           <div class="not">
-            <h2 class="subtitle">会員でない方はこちら</h2>
+            <h2 class="subtitle">はじめましての方はこちら</h2>
             <div>
               <v-btn color="warning" @click="resisterBtn">新規会員登録をして予約する</v-btn>
-              <v-btn color="warning" @click="skipBtn">会員登録せずに予約へ進む</v-btn>
             </div>
             <div class="free">
               ※会員登録は無料です。<br>
@@ -60,13 +59,7 @@ export default {
   },
   methods: {
     resisterBtn() {
-      // 会員登録あり
       this.setIsCreate(true)
-      this.$router.push({ path: '/registration', query: this.query })
-    },
-    skipBtn() {
-      // 会員登録なし
-      this.setIsCreate(false)
       this.$router.push({ path: '/registration', query: this.query })
     },
     ...mapMutations('user', ['setIsCreate'])

--- a/pages/mypage/login.vue
+++ b/pages/mypage/login.vue
@@ -13,7 +13,7 @@
           <div>
             <h2 class="subtitle">会員の方はこちら</h2>
             <login-form :link="link" />
-            <nuxt-link to="/password/reset">
+            <nuxt-link v-if="!user.errorMessage" to="/password/reset">
               パスワードを忘れた方はこちら
             </nuxt-link>
           </div>

--- a/store/user.js
+++ b/store/user.js
@@ -267,7 +267,6 @@ export const actions = {
 
       return true
     } catch (error) {
-      console.log(error)
       commit('setErrorMessage', 'ログインに失敗しました。')
     } finally {
       commit('setIsLoading', false)

--- a/store/user.js
+++ b/store/user.js
@@ -285,10 +285,9 @@ export const actions = {
       dispatch('setLoginCustomer', result.data.data)
       return true
     } catch (error) {
-      console.log(error)
       const errorMessage =
         get(error, 'response.status') === 422
-          ? '登録済みのメールアドレスです。'
+          ? 'すでにご登録済みのメールアドレスです。'
           : 'ユーザー作成に失敗しました。'
       commit('setErrorMessage', errorMessage)
       return false


### PR DESCRIPTION
## 概要
- 非会員予約の導線をなくす
- 会員という言葉をなくす
    - 非会員の場合は、「はじめましての方はこちら」のような文言にする
- パスワードを忘れた時の導線などを強化する
- 会員の二重登録時のエラー文言を検討する

## Trello
【FE】非会員予約をできないようにする ( https://trello.com/c/i3YywkM3 )

## TODO
- [x] パスワードを忘れた時の導線などを強化する
- [x] 会員の二重登録時のエラー文言を検討する