### PR TITLE
会員情報登録→日付入力に戻っても、日付の選択値がクリアされない

### DIFF
--- a/components/pages/date/BackBtn.vue
+++ b/components/pages/date/BackBtn.vue
@@ -15,7 +15,8 @@
 export default {
   methods: {
     back() {
-      this.$router.go(-1)
+      this.$root.context.store.commit('reservation/select/reset')
+      this.$router.push('/menus/', { shopId: this.$root.context.query.shopId })
     }
   }
 }

--- a/middleware/clear-selected-date.js
+++ b/middleware/clear-selected-date.js
@@ -1,0 +1,9 @@
+export default function({ store, query, redirect }) {
+  if (!('dateTime' in query)) {
+    return
+  }
+
+  store.commit('reservation/select/setSelectedDateTime', null)
+  delete query.dateTime
+  redirect('/date/', { ...query })
+}

--- a/pages/date/index.vue
+++ b/pages/date/index.vue
@@ -21,7 +21,7 @@ import BackBtn from '~/components/pages/date/BackBtn.vue'
 import Loading from '~/components/layouts/Loading.vue'
 
 export default {
-  middleware: ['init-shop-id', 'fetch-menus-from-query'],
+  middleware: ['init-shop-id', 'clear-selected-date', 'fetch-menus-from-query'],
   components: {
     RegistrationMenu,
     Calendar,

--- a/pages/menus/index.vue
+++ b/pages/menus/index.vue
@@ -30,9 +30,13 @@ export default {
   middleware: ['init-menu-index', 'init-shop-id'],
   watchQuery: ['shopId'],
   async fetch({ store, query, error }) {
+    if (store.state.shop.id && store.getters['menu/hasSubShops']) {
+      return
+    }
+
+    // shopIdがnullの場合は1をセットする
+    const shopId = query.shopId || 1
     try {
-      // shopIdがnullの場合は1をセットする
-      const shopId = query.shopId || 1
       await Promise.all([
         store.dispatch('shop/getShop', { id: shopId }),
         store.dispatch('menu/getMenus', { shopId })

--- a/pages/mypage/login.vue
+++ b/pages/mypage/login.vue
@@ -59,7 +59,6 @@ export default {
   },
   methods: {
     createBtn() {
-      // this.setIsCreate(true)
       this.$router.push('/create')
     },
     ...mapMutations('user', ['setIsCreate'])


### PR DESCRIPTION
# 対応内容
- 日付から情報登録画面に戻らないようにする
- 日付画面に遷移した際は、選択値をクリアする
- メニュー選択画面のデータfetchを、毎度走らせないようにする