### PR TITLE
カスタムイベントを発火させるコードを追加

### DIFF
--- a/pages/complete/index.vue
+++ b/pages/complete/index.vue
@@ -67,6 +67,12 @@ export default {
       return this.$store.state.user
     }
   },
+  created() {
+    const shopId = this.$route.query.shopId
+    this.$gtm.pushEvent({
+      event: `complete-reseravation-${shopId}`
+    })
+  },
   methods: {
     ...mapActions('reservation', ['resetAllInputed'])
   }


### PR DESCRIPTION
### カスタムイベントを発火させるコードを追加
windowオプジェクトを使うため、createdに発火処理を追加。