### PR TITLE
パスワードリセット画面でのエラーメッセージがおかしいので修正する

### DIFF
--- a/pages/password/mail.vue
+++ b/pages/password/mail.vue
@@ -21,7 +21,10 @@ export default {
     try {
       await store.dispatch('user/sendPasswrodResetMail')
     } catch (e) {
-      error({ statusCode: (e.response && e.response.status) || 500 })
+      error({
+        statusCode: (e.response && e.response.status) || 500,
+        message: e.message || ''
+      })
     }
   },
   methods: {

--- a/store/user.js
+++ b/store/user.js
@@ -311,10 +311,18 @@ export const actions = {
     }
   },
   async sendPasswrodResetMail({ state, commit }) {
-    await axios.post(process.env.api.customerReset, {
-      email: state.mail,
-      redirect_url: `${window.location.origin}/password/set/`
-    })
+    await axios
+      .post(process.env.api.customerReset, {
+        email: state.mail,
+        redirect_url: `${window.location.origin}/password/set/`
+      })
+      .catch(e => {
+        const error = new Error(
+          '登録されていないメールアドレスが入力されました。<br>正しいメールアドレスを再度ご入力ください。'
+        )
+        error.statusCode = 500
+        throw error
+      })
     commit('reset')
   },
   async updatePassword({ state, getters, commit }) {


### PR DESCRIPTION
## 概要
パスワードリセット画面にて、登録されていないメアドを入力時にエラーメッセージが適切でないため修正

## Trello
【FE】パスワードリセット画面でのエラーメッセージがおかしいので修正する ( https://trello.com/c/dVTsxv3o )