### PR TITLE
マイページのメニューに店舗を追加

### DIFF
--- a/components/pages/mypage/Navbar.vue
+++ b/components/pages/mypage/Navbar.vue
@@ -109,6 +109,14 @@ export default {
             {
               title: '札幌円山店',
               function: () => this.reserve(4)
+            },
+            {
+              title: '川崎宮崎台店',
+              function: () => this.reserve(5)
+            },
+            {
+              title: '横浜美しが丘店',
+              function: () => this.reserve(6)
             }
           ]
         }


### PR DESCRIPTION
### 変更内容
・マイページのメニューに川崎宮崎台店と横浜美しが丘店のリンクを追加。